### PR TITLE
Delete the ports config line to not expose model-service on host machine

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,8 +12,6 @@ services:
 
   model-service:
     image: "ghcr.io/remla25-team20/model-service:latest"
-    ports:
-      - ":8080"
     environment:
       - NODE_ENV=production
       - PORT=8080


### PR DESCRIPTION
The previous fix only assigned random port on host machine instead of not exposing it at all.