### PR TITLE
Feature/istio2

### DIFF
--- a/ansible/ctrl.yaml
+++ b/ansible/ctrl.yaml
@@ -60,3 +60,7 @@
         - helm
     # - name: Install Helm diff package
     #   ansible.builtin.command: helm plugin install https://github.com/databus23/helm-diff
+    - name: Enable Istio injection in default namespace
+      ansible.builtin.command: kubectl label namespace default istio-injection=enabled
+      environment:
+        KUBECONFIG: /etc/kubernetes/admin.conf

--- a/ansible/general.yaml
+++ b/ansible/general.yaml
@@ -66,7 +66,7 @@
       ansible.builtin.apt:
         name:
         - containerd=1.7.24-0ubuntu1~24.04.2
-        - runc=1.1.12-0ubuntu3.1
+        - runc=1.1.12-0ubuntu3
         - kubelet={{ k8s_version }}
         - kubeadm={{ k8s_version }}
         - kubectl={{ k8s_version }}

--- a/app-chart/templates/deployment.yaml
+++ b/app-chart/templates/deployment.yaml
@@ -3,17 +3,18 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: model-service-deployment
-  labels:
-    app: model-service
+  labels: { app: model-service, version: "{{ .Values.modelService.version }}" }
 spec:
   replicas: 3
   selector:
     matchLabels:
       app: model-service
+      version: "{{ .Values.modelService.version }}"
   template:
     metadata:
       labels:
         app: model-service
+        version: "{{ .Values.modelService.version }}"
     spec:
       containers:
       - name: model-service
@@ -24,22 +25,78 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  name: model-service-deployment-canary
+  labels: { app: model-service, version: "{{ .Values.modelService.versionCanary }}" }
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: model-service
+      version: "{{ .Values.modelService.versionCanary }}"
+  template:
+    metadata:
+      labels:
+        app: model-service
+        version: "{{ .Values.modelService.versionCanary }}"
+    spec:
+      containers:
+      - name: model-service
+        image: ghcr.io/remla25-team20/model-service:{{  .Values.modelService.versionCanary  }}
+        ports:
+        - containerPort: {{ .Values.modelService.port }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
   name: app-deployment
-  labels:
-    app: app
+  labels: { app: app, version: "{{ .Values.app.version }}" }
 spec:
   replicas: 3
   selector:
     matchLabels:
       app: app
+      version: "{{ .Values.app.version }}"
   template:
     metadata:
       labels:
         app: app
+        version: "{{ .Values.app.version }}"
     spec:
       containers:
       - name: app
         image: "ghcr.io/remla25-team20/app:{{ .Values.app.version  }}"
+        ports:
+        - containerPort: 3000
+        env:
+        - name: NODE_ENV
+          value: "production"
+        - name: PORT
+          value: "3000"
+        - name: HOSTNAME
+          value: "0.0.0.0"
+        - name: NEXT_PUBLIC_API_BASE_URL
+          value: "{{ .Values.modelService.name  }}:{{  .Values.modelService.port  }}"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app-deployment-canary
+  labels: { app: app, version: "{{ .Values.app.versionCanary }}" }
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: app
+      version: "{{ .Values.app.versionCanary }}"
+  template:
+    metadata:
+      labels:
+        app: app
+        version: "{{ .Values.app.versionCanary }}"
+    spec:
+      containers:
+      - name: app
+        image: "ghcr.io/remla25-team20/app:{{ .Values.app.versionCanary  }}"
         ports:
         - containerPort: 3000
         env:

--- a/app-chart/templates/istio.yaml
+++ b/app-chart/templates/istio.yaml
@@ -9,12 +9,37 @@ spec:
 ---
 apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
-metadata: { name: entry-service }
+metadata:
+  name: entry-service
 spec:
-  gateways: [ gateway ]
-  hosts: [ "*" ]
+  gateways:
+    - gateway
+  hosts:
+    - "*"
   http:
     - match:
-        - uri: { prefix: / }
+        - uri:
+            prefix: /
       route:
-        - destination: { host: app-service }
+        - destination:
+            host: app-service
+            subset: v1
+          weight: 90
+        - destination:
+            host: app-service
+            subset: v2
+          weight: 10
+---
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: app-service
+spec:
+  host: app-service
+  subsets:
+    - name: v1
+      labels:
+        version: "{{ .Values.app.version }}"
+    - name: v2
+      labels:
+        version: "{{ .Values.app.versionCanary }}"

--- a/app-chart/templates/istio.yaml
+++ b/app-chart/templates/istio.yaml
@@ -43,3 +43,37 @@ spec:
     - name: v2
       labels:
         version: "{{ .Values.app.versionCanary }}"
+---
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: model-service-dr
+spec:
+  host: model-service
+  subsets:
+    - name: v1
+      labels:
+        version: "{{ .Values.modelService.version }}"
+    - name: v2
+      labels:
+        version: "{{ .Values.modelService.versionCanary }}"
+---
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: model-service-vs
+spec:
+  hosts:
+    - model-service
+  http:
+    - match:
+        - sourceLabels:
+            version: "{{ .Values.app.versionCanary }}"
+      route:
+        - destination:
+            host: model-service
+            subset: v2
+    - route:
+        - destination:
+            host: model-service
+            subset: v1

--- a/app-chart/templates/istio.yaml
+++ b/app-chart/templates/istio.yaml
@@ -1,0 +1,20 @@
+apiVersion: networking.istio.io/v1beta1
+kind: Gateway
+metadata: { name: gateway }
+spec:
+  selector: { istio: ingressgateway }
+  servers:
+    - port: { number: 80, name: http, protocol: HTTP }
+      hosts: [ "*" ]
+---
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata: { name: entry-service }
+spec:
+  gateways: [ gateway ]
+  hosts: [ "*" ]
+  http:
+    - match:
+        - uri: { prefix: / }
+      route:
+        - destination: { host: app-service }

--- a/app-chart/values.yaml
+++ b/app-chart/values.yaml
@@ -129,10 +129,12 @@ affinity: {}
 modelService:
   name: model-service
   version: 0.1.3 # this version has the most recent metrics
+  versionCanary: 0.1.2 
   port: 8080
 
 app:
   version: 0.2.0
+  versionCanary: 0.1.0
 
 serviceMonitor:
   enabled: true          

--- a/app-chart/values.yaml
+++ b/app-chart/values.yaml
@@ -129,12 +129,12 @@ affinity: {}
 modelService:
   name: model-service
   version: 0.1.3 # this version has the most recent metrics
-  versionCanary: 0.1.3 
+  versionCanary: 0.1.4
   port: 8080
 
 app:
   version: 0.2.0
-  versionCanary: 0.3.0
+  versionCanary: 0.2.1
 
 serviceMonitor:
   enabled: true          

--- a/app-chart/values.yaml
+++ b/app-chart/values.yaml
@@ -129,12 +129,12 @@ affinity: {}
 modelService:
   name: model-service
   version: 0.1.3 # this version has the most recent metrics
-  versionCanary: 0.1.2 
+  versionCanary: 0.1.3 
   port: 8080
 
 app:
   version: 0.2.0
-  versionCanary: 0.1.0
+  versionCanary: 0.2.0
 
 serviceMonitor:
   enabled: true          

--- a/app-chart/values.yaml
+++ b/app-chart/values.yaml
@@ -134,7 +134,7 @@ modelService:
 
 app:
   version: 0.2.0
-  versionCanary: 0.2.0
+  versionCanary: 0.3.0
 
 serviceMonitor:
   enabled: true          


### PR DESCRIPTION
I finished up to good for Traffic Management. I created a new variable versionCanary for both app and modelService. I create two more deployments that take these versions, right now ive set versionCanary to versions that don't exist. To acces the app via the istio ingress gateway you should add 192.168.56.91 app-istio.local to  /etc/hosts, and then you can acces with app-istio.local in browser. I've not removed the nginx ingress so that is also still accesible. 

It's a bit cumbersome but you can check if consistent and weighted routing work via:

In values.yaml 
-------------------------------------
modelService:
  name: model-service
  version: 0.1.3 # this version has the most recent metrics
  versionCanary: 0.1.4
  port: 8080

app:
  version: 0.2.0
  versionCanary: 0.2.1
---------------------------------------
 
should give 90/10 distribution of the frontend failing when refreshing.

------------------------------------
modelService:
  name: model-service
  version: 0.1.4 # this version has the most recent metrics
  versionCanary: 0.1.3
  port: 8080

app:
  version: 0.2.0
  versionCanary: 0.2.1
 ------------------------------------------
should always raise prediction error when frontend is up, proves consistency.




