### PR TITLE
Fix/idempotency2

### DIFF
--- a/ansible/ctrl.yaml
+++ b/ansible/ctrl.yaml
@@ -40,6 +40,7 @@
       ansible.builtin.command: kubectl apply -f /tmp/kube-flannel.yml
       environment:
         KUBECONFIG: /etc/kubernetes/admin.conf
+      changed_when: false
     - name: Add Helm ASC key
       ansible.builtin.apt_key:
         url: https://baltocdn.com/helm/signing.asc
@@ -60,7 +61,14 @@
         - helm
     # - name: Install Helm diff package
     #   ansible.builtin.command: helm plugin install https://github.com/databus23/helm-diff
+    - name: Check if Istio injection is enabled in default namespace
+      ansible.builtin.command: kubectl get namespace default -o jsonpath='{.metadata.labels.istio-injection}'
+      register: istio_injection
+      environment:
+        KUBECONFIG: /etc/kubernetes/admin.conf
+      changed_when: false
     - name: Enable Istio injection in default namespace
       ansible.builtin.command: kubectl label namespace default istio-injection=enabled
       environment:
         KUBECONFIG: /etc/kubernetes/admin.conf
+      when: istio_injection.stdout != 'enabled'

--- a/ansible/finalization.yml
+++ b/ansible/finalization.yml
@@ -9,6 +9,7 @@
         dest: /tmp/metallb-native.yaml
     - name: Apply Flannel manifest
       ansible.builtin.command: kubectl apply -f /tmp/metallb-native.yaml
+      changed_when: false
     # Cert-Manager will allow us to use self-signed certificates
     - name: Add cert-manager Helm repo
       kubernetes.core.helm_repository:
@@ -28,6 +29,7 @@
         dest: /tmp/selfsigned-issuer.yaml
     - name: Apply selfsigned-issuer manifest
       ansible.builtin.command: kubectl apply -f /tmp/selfsigned-issuer.yaml
+      changed_when: false
     - name: Wait until metallb is fully initialized
       ansible.builtin.command: >
         kubectl wait
@@ -35,12 +37,14 @@
         -l app=metallb,component=controller --for=condition=ready
         pod
         --timeout=60s
+      changed_when: false
     - name: Copy metallb resource definition manifest to VM
       ansible.builtin.copy:
         src: resources/metallb-resources.yaml
         dest: /tmp/metallb-resources.yaml
     - name: Initialize IPAddressPool and L2Advertisement
       ansible.builtin.command: kubectl apply -f /tmp/metallb-resources.yaml
+      changed_when: false
     - name: Add Ingress-Nginx Helm repository
       kubernetes.core.helm_repository:
         name: ingress-nginx
@@ -53,6 +57,7 @@
         name: ingress-nginx
         set_values:
           - value: controller.service.loadBalancerIP=192.168.56.90
+      changed_when: false
     - name: Add Kubernetes-dashboard Helm repository
       kubernetes.core.helm_repository:
         name: kubernetes-dashboard
@@ -80,8 +85,10 @@
         -l app.kubernetes.io/name=ingress-nginx,app.kubernetes.io/component=controller --for=condition=ready
         pod
         --timeout=60s
+      changed_when: false
     - name: Apply Dashboard Ingress manifest
       ansible.builtin.command: kubectl apply -f /tmp/dashboard-ingress.yaml
+      changed_when: false
 # Needed for monitoring
     - name: Add Prometheus Community repo
       kubernetes.core.helm_repository:

--- a/ansible/finalization.yml
+++ b/ansible/finalization.yml
@@ -74,6 +74,7 @@
         dest: /tmp/dashboard-adminuser.yaml
     - name: Apply adminuser manifest
       ansible.builtin.command: kubectl apply -f /tmp/dashboard-adminuser.yaml
+      changed_when: false
     - name: Copy ingress manifest for dashboard
       ansible.builtin.copy:
         src: resources/dashboard-ingress.yaml
@@ -141,4 +142,5 @@
         istioctl install -y -f /tmp/istio-gateway.yml
       args:
         chdir: /home/vagrant
+      changed_when: false
 

--- a/ansible/general.yaml
+++ b/ansible/general.yaml
@@ -75,9 +75,14 @@
         path: /etc/containerd
         state: directory
         mode: '0755'
+    - name: check if containerd config.toml exists
+      ansible.builtin.stat:
+        path: /etc/containerd/config.toml
+      register: containerd_config_stat
     - name: Generate the output of default containerd config
       ansible.builtin.command: containerd config default
       register: containerd_config
+      when: not containerd_config_stat.stat.exists
     - name: Write default config to /etc/containerd/config.toml
       ansible.builtin.copy:
         dest: /etc/containerd/config.toml
@@ -85,6 +90,7 @@
         owner: root
         group: root
         mode: '0644'
+      when: not containerd_config_stat.stat.exists
     - name: Update specific values in containerd config.toml
       ansible.builtin.replace:
         path: /etc/containerd/config.toml
@@ -94,10 +100,12 @@
         - { key: "disable_apparmor", value: "true", section: 'plugins."io.containerd.grpc.v1.cri"'}
         - { key: "sandbox_image", value: '"registry.k8s.io/pause:3.10"', section: 'plugins."io.containerd.grpc.v1.cri"'}
         - { key: "SystemdCgroup", value: "true", section: 'plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options'}
+      when: not containerd_config_stat.stat.exists
     - name: Restart containerd
       ansible.builtin.service:
         name: containerd
         state: restarted
+      when: not containerd_config_stat.stat.exists
     - name: Start kubelet service
       ansible.builtin.service:
         name: kubelet

--- a/ansible/general.yaml
+++ b/ansible/general.yaml
@@ -14,6 +14,7 @@
         - "keys/*.pub"
     - name: Disable SWAP
       ansible.builtin.shell: swapoff -a
+      changed_when: false
     - name: Disable SWAP in fstab
       ansible.builtin.lineinfile:
         path: /etc/fstab


### PR DESCRIPTION
Small PR that contains some idempotency fixes. Note that kubectl, helm (and istioctl to some extent) are designed to be idempotent under the hood. Therefore i've added changed_when: false to these blocks, to suppres the 'changed' state ansible would else keep throwing. Right now ansible will return only 'ok' or 'skipping' states when provisioning identical configurations.